### PR TITLE
slice function in action

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'helpers.php';
+require_once 'utils.php';
 $is_auth = rand(0, 1);
 
 $user_name = 'the-nepodarok'; // укажите здесь ваше имя
@@ -270,7 +271,7 @@ $posts = [
                     <!--содержимое для поста-текста-->
                     <p>
                         <!--здесь текст-->
-                        <?= $post['post_content']; ?>
+                        <?= slice_string($post['post_content']); ?>
                     </p>
                     <?php break; ?>
 

--- a/utils.php
+++ b/utils.php
@@ -45,5 +45,5 @@ function slice_string_2($string, $max_post_length = 300)
             '...</p><a class="post-text__more-link" href="#">Читать далее</a>';
     }
 
-    return trim($result_string);
+    return $result_string;
 }

--- a/utils.php
+++ b/utils.php
@@ -11,18 +11,22 @@
 
 function slice_string($string, $max_post_length = 300)
 {
-    if (mb_strlen($string) > $max_post_length) {
-        $words = explode(' ', $string);
+    $result_string = $string;
+
+    if (mb_strlen($result_string) > $max_post_length) {
+        $words = explode(' ', $result_string);
         $i = 0;
         $result_string = '';
+        $addition = '...' . '/n' . 'Читать далее'; // для полного соответствия заданию, где показано, что текст должен обрезаться С УЧЁТОМ добавляемых нами ссылки и многоточий (я тестировал на тексте про озеро);
 
-        while (mb_strlen($result_string . ' ' . $words[$i]) < $max_post_length) {
-            $result_string = $result_string . ' ' . $words[$i];
+        while (mb_strlen($result_string . ' ' . $words[$i] . $addition) < $max_post_length) {
+            $result_string .= ' ' . $words[$i];
             $i++;
         }
-        $result_string = '<p>' . trim($result_string) . '...</p><a class="post-text__more-link" href="#">Читать далее</a>';
-    } else {
-        $result_string = '<p>' . trim($string) . '</p>';
+
+        $result_string = '<p>' . trim($result_string, '/ :–-,;') . '...</p><a class="post-text__more-link" href="#">Читать далее</a>';
+        // trim нужен здесь, потому что пробел в начале параграфа добавляется на этапе цикла и trim в начале (равно как и в конце) не поможет;
+        // знаки препинания я всё-таки убираю, потому что в задании как бы требуется, чтобы строка обрезалась именно по слову;
     }
 
     return $result_string;
@@ -30,13 +34,14 @@ function slice_string($string, $max_post_length = 300)
 
 //  Второй вариант функции
 
-function alt_slice_string($string, $max_post_length = 300)
+function slice_string_2($string, $max_post_length = 300)
 {
-    if (mb_strlen($string) <= $max_post_length) {
-        $result_string = '<p>' . trim($string) . '</p>';
-    } else {
-        $temp_string = mb_substr($string, 0, $max_post_length);
-        $result_string = '<p>' . trim(mb_substr($temp_string, 0, mb_strripos($temp_string, ' '))) .
+    $result_string = trim($string);
+    $addition = '...' . '/n' . 'Читать далее'; // для полного соответствия заданию, текст вместе с $addition не превышает указанный лимит
+
+    if (mb_strlen($result_string) > $max_post_length) {
+        $temp_string = mb_substr($string, 0, $max_post_length - mb_strlen($addition));
+        $result_string = '<p>' . mb_substr($temp_string, 0, mb_strripos($temp_string, ' ')) .
             '...</p><a class="post-text__more-link" href="#">Читать далее</a>';
     }
 


### PR DESCRIPTION
То, что функцию надо внедрять в разметку уже на этом этапе, я и не заметил... и тут сразу начались проблемы.
Во-первых, действительно, лишние `<p></p>`. 
Во-вторых же, обрезанный текст получался длиннее, чем нужно (проверял на тексте про озеро, и по скриншоту в задании он должен обрезаться на слове "озера..." - пришлось постараться добиться этого путём включения длины добавляемых символов в расчёты. Приложу скриншот в подтверждение
![readme](https://user-images.githubusercontent.com/92626889/198828353-2e2c17d6-2bde-4cdd-9ae2-6bc644c3e5aa.png)

Заодно так получилось, что и else ветки отпали за ненадобностью.
Долго экспериментировал с тем, где всё-таки делать trim, в итоге он теперь там, где есть -- опять-таки из-за особенностей задания
